### PR TITLE
Replace all dashes in option names.

### DIFF
--- a/lib/cl/opt.rb
+++ b/lib/cl/opt.rb
@@ -37,7 +37,7 @@ class Cl
     def name
       return @name if instance_variable_defined?(:@name)
       name = long.split(' ').first.match(OPT)[1] if long
-      @name = name.sub('-', '_').to_sym if name
+      @name = name.gsub('-', '_').to_sym if name
     end
 
     def type

--- a/spec/opts_spec.rb
+++ b/spec/opts_spec.rb
@@ -52,13 +52,16 @@ describe Cl, 'opts' do
   end
 
   describe 'dashed opts' do
-    let(:opts) { ->(*) { opt('--one_two') } }
+    let(:opts) { ->(*) { opt('--one_two_three') } }
 
-    it { expect(cmd(%w(cmd --one_two)).opts[:one_two]).to be true }
-    it { expect(cmd(%w(cmd --one_two)).one_two?).to be true }
+    it { expect(cmd(%w(cmd --one_two_three)).opts[:one_two_three]).to be true }
+    it { expect(cmd(%w(cmd --one_two_three)).one_two_three?).to be true }
 
-    it { expect(cmd(%w(cmd --one-two)).opts[:one_two]).to be true }
-    it { expect(cmd(%w(cmd --one-two)).one_two?).to be true }
+    it { expect(cmd(%w(cmd --one-two-three)).opts[:one_two_three]).to be true }
+    it { expect(cmd(%w(cmd --one-two-three)).one_two_three?).to be true }
+
+    it { expect(cmd(%w(cmd --one-two_three)).opts[:one_two_three]).to be true }
+    it { expect(cmd(%w(cmd --one_two-three)).one_two_three?).to be true }
   end
 
   describe 'does not dasherize values' do


### PR DESCRIPTION
Without this, you get weird options like:
  opt 'mongodb-cluster-name' -> `mongodb_cluster-name`

After this change:
  opt 'mongodb-cluster-name' => `mongodb_cluster_name`